### PR TITLE
Add step to install init script to generate MAC in u-boot.txt

### DIFF
--- a/scripts/S99install-MiSTer.sh
+++ b/scripts/S99install-MiSTer.sh
@@ -46,6 +46,17 @@ fi
 ## Custom config support
 cp -r /mnt/release/config /tmp/release/files/
 
+## Generate a locally administered unicast MAC address for ethernet NIC
+MAC=$(hexdump -n 6 -ve '1/1 "%.2x "' /dev/random | \
+  awk -v a="2,6,a,e" -v r="$RANDOM" \
+  'BEGIN { srand(r); }
+  NR==1 { split(a,b,",");
+  r=int(rand()*4+1);
+  printf("%s%s:%s:%s:%s:%s:%s\n", substr($1,0,1),b[r],$2,$3,$4,$5,$6); }' | \
+  tr "[:lower:]" "[:upper:]")
+mkdir -p /tmp/release/files/linux
+echo "ethaddr=${MAC}" > /tmp/release/files/linux/u-boot.txt
+
 ## SDL Game Controller DB support
 mkdir -p /tmp/release/files/linux/gamecontrollerdb
 cp -r /mnt/release/gamecontrollerdb.txt /tmp/release/files/linux/gamecontrollerdb/


### PR DESCRIPTION
This pull request adds a step to the S99install-mister.sh script to generate a random locally administered unicast MAC address for the ethernet NIC and writes it to the linux/u-boot.txt file on the fresh MiSTer install.

This addresses the issue of all MiSTers having the same ethernet MAC address by default, meaning that anyone who owns more than one MiSTer either must know in advance to change it, or find out the hard way about MAC collisions.

It has a risk of the generated MAC address colliding with another on the user's network. But I believe this risk is extremely low, and the risk already exists with the existing solution (and arguably a much higher risk considering it's a common sequence of numbers).